### PR TITLE
Fix:  Docs for default export require statements updated

### DIFF
--- a/packages/http-logger/readme.md
+++ b/packages/http-logger/readme.md
@@ -18,7 +18,7 @@ yarn add @sliit-foss/http-logger
 
 ```js
 # using require
-const httpLogger = require("@sliit-foss/http-logger");
+const httpLogger = require("@sliit-foss/http-logger").default;
 
 # using import
 import httpLogger from "@sliit-foss/http-logger";

--- a/packages/service-connector/readme.md
+++ b/packages/service-connector/readme.md
@@ -18,7 +18,7 @@ yarn add @sliit-foss/service-connector
 
 ```js
 # using require
-const serviceConnector = require("@sliit-foss/service-connector");
+const serviceConnector = require("@sliit-foss/service-connector").default;
 
 # using import
 import serviceConnector from "@sliit-foss/service-connector";


### PR DESCRIPTION
- add missing .default for require statements in http-logger
- add missing .default for require statements in service connector

For further reference read [this](https://stackoverflow.com/questions/33704714/cant-require-default-export-value-in-babel-6-x).