### PR TITLE
Add: New package JSON hash added

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prettier": "3.2.5"
   },
   "engines": {
-    "node": ">=14.0.0"
-  },
-  "packageManager": "pnpm@7.5.0"
+    "node": ">=14.0.0",
+    "pnpm": ">=7.5.0"
+  }
 }

--- a/packages/json-hash/package.json
+++ b/packages/json-hash/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "json-hash",
+  "version": "1.0.0",
+  "description": "Hash JS objects reliablly on both Node.js and browser",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "node ../../scripts/esbuild.config.js",
+    "build:watch": "bash ../../scripts/esbuild.watch.sh",
+    "bump-version": "bash ../../scripts/bump-version.sh --name=@sliit-foss/json-hash",
+    "lint": "bash ../../scripts/lint.sh",
+    "release": "bash ../../scripts/release.sh",
+    "test": "bash ../../scripts/test/test.sh"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sliit-foss/npm-catalogue.git"
+  },
+  "dependencies": {
+    "json-stable-stringify": "1.1.1"
+  },
+  "devDependencies": {
+    "lodash": "4.17.10"
+  },
+  "keywords": [
+    "json",
+    "hash",
+    "hashing",
+    "object-hash"
+  ],
+  "author": "SLIIT FOSS",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/sliit-foss/npm-catalogue/issues"
+  }
+}

--- a/packages/json-hash/src/algorthms.js
+++ b/packages/json-hash/src/algorthms.js
@@ -1,0 +1,18 @@
+export const algos = {
+  "SHA-1": "sha1",
+  "SHA-256": "sha256",
+  "SHA-384": "sha384",
+  "SHA-512": "sha512"
+};
+
+export const getNodeJSAlgoName = (algorithm) => {
+  return algos[algorithm];
+};
+
+export const isAvailableAlgo = (algorithm) => {
+  if (Object.prototype.hasOwnProperty.call(algos, algorithm)) {
+    return true;
+  }
+
+  return false;
+};

--- a/packages/json-hash/src/index.js
+++ b/packages/json-hash/src/index.js
@@ -1,0 +1,47 @@
+import { getNodeJSAlgoName, isAvailableAlgo } from "./algorithms.js";
+
+export const computeHash = async (obj, { algorithm = "SHA-1", sort = false }) => {
+  if (!isAvailableAlgo(algorithm)) {
+    throw new Error("Provided algorithm is not available");
+  }
+
+  if (typeof obj !== "string") {
+    if (sort) {
+      const { default: stringify } = await import("json-stable-stringify");
+      obj = stringify(obj);
+    } else {
+      obj = JSON.stringify(obj);
+    }
+  }
+
+  // For browser
+  // eslint-disable-next-line no-undef
+  if (typeof window !== "undefined" && window.crypto && window.crypto.subtle) {
+    const msgUint8 = new TextEncoder().encode(obj); // encode as (utf-8) Uint8Array
+
+    // eslint-disable-next-line no-undef
+    const hashBuffer = await window.crypto.subtle.digest(algorithm, msgUint8); // hash data
+    const hashArray = Array.from(new Uint8Array(hashBuffer)); // convert buffer to byte array
+    const hashHex = hashArray.map((b) => b.toString(16).padStart(2, "0")).join(""); // convert bytes to hex string
+    return hashHex;
+  }
+
+  // For Node.js
+  if (typeof global !== "undefined" && global.crypto) {
+    const { createHash } = await import("crypto");
+    const hash = createHash(getNodeJSAlgoName(algorithm)).update(obj).digest("hex");
+    return hash;
+  }
+};
+
+// (async () => {
+//   const obj = { name: "John", age: 30 };
+//   const algorithm = "SHA-256";
+
+//   try {
+//     const hash = await computeHash(obj, { algorithm, sort: true });
+//     console.log(`Hash (${algorithm}):`, hash);
+//   } catch (error) {
+//     console.error(error);
+//   }
+// })();

--- a/packages/json-hash/test/index.test.js
+++ b/packages/json-hash/test/index.test.js
@@ -1,0 +1,173 @@
+import { cloneDeep } from "lodash";
+import { computeHash } from "../src";
+import { getNodeJSAlgoName, isAvailableAlgo } from "../src/algorthms";
+
+describe("json-hash-node-js", () => {
+  const objectToHash = { name: "Siri", age: 30, country: "Sri Lanka" };
+
+  beforeAll(() => {
+    global.unit_tests_running = true;
+  });
+
+  afterAll(() => {
+    global.unit_tests_running = false;
+  });
+
+  //tests for getNodeJSAlgoName
+  it("should-get-node-js-algo-name", () => {
+    expect(getNodeJSAlgoName("SHA-1")).toBe("sha1");
+    expect(getNodeJSAlgoName("SHA-256")).toBe("sha256");
+    expect(getNodeJSAlgoName("SHA-384")).toBe("sha384");
+    expect(getNodeJSAlgoName("SHA-512")).toBe("sha512");
+  });
+
+  it("should-not-throw-error-for-invalid-algo-name", () => {
+    expect(getNodeJSAlgoName("NIKE")).toBe(undefined);
+    expect(getNodeJSAlgoName("")).toBe(undefined);
+  });
+
+  //tests for isAvailableAlgo
+  it("should-return-true-if-algo-name-is-available", () => {
+    expect(isAvailableAlgo("SHA-1")).toBe(true);
+  });
+
+  it("should-return-false-if-algo-name-is-not-available", () => {
+    expect(isAvailableAlgo("NIKE")).toBe(false);
+  });
+
+  // tests for compute hash
+
+  // without sorting
+  it("should-compute-hash-with-SHA-1", () => {
+    expect(computeHash(objectToHash, { algorithm: "SHA-1" })).toBe("9edcbfaaba0af491b8f73961416a250655bf483c");
+  });
+
+  it("should-compute-hash-with-SHA-256", () => {
+    expect(computeHash(objectToHash, { algorithm: "SHA-256" })).toBe(
+      "f17f5b4a7b8d4f7258cfedff4b78982f6d472d856d1fc1a9da3562d633ffff72"
+    );
+  });
+
+  it("should-compute-hash-with-SHA-384", () => {
+    expect(computeHash(objectToHash, { algorithm: "SHA-384" })).toBe(
+      "8096ba11adb69941ad3ff5cbfc8c4b00d9b8d092de640e8abf8b54e1fcb7ddfdeaa3f5df0f03af50ca2648e76ed704b5"
+    );
+  });
+
+  it("should-compute-hash-with-SHA-512", () => {
+    expect(computeHash(objectToHash, { algorithm: "SHA-512" })).toBe(
+      "e6dc6e4edb2de44db04a6611ce3bb7127d9c5e93d8cc8c2092fca748db04d676ebf12dd06f6819eb6b7b20f957025e2da490918511adf34775e869e17619180e"
+    );
+  });
+
+  // with sorting
+  it("should-sort-and-compute-hash-with-SHA-1", () => {
+    expect(computeHash(objectToHash, { algorithm: "SHA-1", sort: true })).toBe(
+      "10e3e5df394451377f778d7402b62b5134dca39a"
+    );
+  });
+
+  it("should-sort-and-compute-hash-with-SHA-256", () => {
+    expect(computeHash(objectToHash, { algorithm: "SHA-256", sort: true })).toBe(
+      "37d0042f1f11c95c8563b530cc8769d4229ef48b5a31f763e2f841783216d6f2"
+    );
+  });
+
+  it("should-sort-and-compute-hash-with-SHA-384", () => {
+    expect(computeHash(objectToHash, { algorithm: "SHA-384", sort: true })).toBe(
+      "f43ccfc81ea4e92fc11bed100e7cd82a665ad359faf91ff666e51a947cba8a7c5e3931ed6e7cebaef1a66b4b3c0c5d41"
+    );
+  });
+
+  it("should-sort-and-compute-hash-with-SHA-512", () => {
+    expect(computeHash(objectToHash, { algorithm: "SHA-512", sort: true })).toBe(
+      "f6a03a2a8cf61713c4c2fc3bae86736f6f8322d5271d1c2b3046268871f3d6ca434b1414b910990c9ba2f13cbe629f54646b7430880f1e60a4a899c94f45b6b1"
+    );
+  });
+});
+
+describe("json-hash-browser", () => {
+  const window = cloneDeep(global.window);
+
+  const objectToHash = { name: "Siri", age: 30, country: "Sri Lanka" };
+
+  beforeAll(() => {
+    global.unit_tests_running = true;
+  });
+
+  afterAll(() => {
+    global.unit_tests_running = false;
+  });
+
+  //tests for getNodeJSAlgoName
+  it("should-get-node-js-algo-name", () => {
+    expect(getNodeJSAlgoName("SHA-1")).toBe("sha1");
+    expect(getNodeJSAlgoName("SHA-256")).toBe("sha256");
+    expect(getNodeJSAlgoName("SHA-384")).toBe("sha384");
+    expect(getNodeJSAlgoName("SHA-512")).toBe("sha512");
+  });
+
+  it("should-not-throw-error-for-invalid-algo-name", () => {
+    expect(getNodeJSAlgoName("NIKE")).toBe(undefined);
+    expect(getNodeJSAlgoName("")).toBe(undefined);
+  });
+
+  //tests for isAvailableAlgo
+  it("should-return-true-if-algo-name-is-available", () => {
+    expect(isAvailableAlgo("SHA-1")).toBe(true);
+  });
+
+  it("should-return-false-if-algo-name-is-not-available", () => {
+    expect(isAvailableAlgo("NIKE")).toBe(false);
+  });
+
+  // tests for compute hash
+
+  // without sorting
+  it("should-compute-hash-with-SHA-1", () => {
+    expect(computeHash(objectToHash, { algorithm: "SHA-1" })).toBe("9edcbfaaba0af491b8f73961416a250655bf483c");
+  });
+
+  it("should-compute-hash-with-SHA-256", () => {
+    expect(computeHash(objectToHash, { algorithm: "SHA-256" })).toBe(
+      "f17f5b4a7b8d4f7258cfedff4b78982f6d472d856d1fc1a9da3562d633ffff72"
+    );
+  });
+
+  it("should-compute-hash-with-SHA-384", () => {
+    expect(computeHash(objectToHash, { algorithm: "SHA-384" })).toBe(
+      "8096ba11adb69941ad3ff5cbfc8c4b00d9b8d092de640e8abf8b54e1fcb7ddfdeaa3f5df0f03af50ca2648e76ed704b5"
+    );
+  });
+
+  it("should-compute-hash-with-SHA-512", () => {
+    expect(computeHash(objectToHash, { algorithm: "SHA-512" })).toBe(
+      "e6dc6e4edb2de44db04a6611ce3bb7127d9c5e93d8cc8c2092fca748db04d676ebf12dd06f6819eb6b7b20f957025e2da490918511adf34775e869e17619180e"
+    );
+  });
+
+  // with sorting
+  it("should-sort-and-compute-hash-with-SHA-1", () => {
+    expect(computeHash(objectToHash, { algorithm: "SHA-1", sort: true })).toBe(
+      "10e3e5df394451377f778d7402b62b5134dca39a"
+    );
+  });
+
+  it("should-sort-and-compute-hash-with-SHA-256", () => {
+    expect(computeHash(objectToHash, { algorithm: "SHA-256", sort: true })).toBe(
+      "37d0042f1f11c95c8563b530cc8769d4229ef48b5a31f763e2f841783216d6f2"
+    );
+  });
+
+  it("should-sort-and-compute-hash-with-SHA-384", () => {
+    expect(computeHash(objectToHash, { algorithm: "SHA-384", sort: true })).toBe(
+      "f43ccfc81ea4e92fc11bed100e7cd82a665ad359faf91ff666e51a947cba8a7c5e3931ed6e7cebaef1a66b4b3c0c5d41"
+    );
+  });
+
+  it("should-sort-and-compute-hash-with-SHA-512", () => {
+    expect(computeHash(objectToHash, { algorithm: "SHA-512", sort: true })).toBe(
+      "f6a03a2a8cf61713c4c2fc3bae86736f6f8322d5271d1c2b3046268871f3d6ca434b1414b910990c9ba2f13cbe629f54646b7430880f1e60a4a899c94f45b6b1"
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: "6.1"
+lockfileVersion: "6.0"
 
 settings:
   autoInstallPeers: true
@@ -112,6 +112,16 @@ importers:
       "@sliit-foss/module-logger":
         specifier: 1.3.1
         version: link:../module-logger
+
+  packages/json-hash:
+    dependencies:
+      json-stable-stringify:
+        specifier: 1.1.1
+        version: 1.1.1
+    devDependencies:
+      lodash:
+        specifier: 4.17.10
+        version: 4.17.10
 
   packages/leaderboard:
     dependencies:
@@ -4008,6 +4018,18 @@ packages:
       get-intrinsic: 1.2.0
     dev: true
 
+  /call-bind@1.0.7:
+    resolution:
+      { integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w== }
+    engines: { node: ">= 0.4" }
+    dependencies:
+      es-define-property: 1.0.0
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.2.4
+      set-function-length: 1.2.2
+    dev: false
+
   /callsites@3.1.0:
     resolution:
       { integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ== }
@@ -4494,6 +4516,16 @@ packages:
       clone: 1.0.4
     dev: false
 
+  /define-data-property@1.1.4:
+    resolution:
+      { integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A== }
+    engines: { node: ">= 0.4" }
+    dependencies:
+      es-define-property: 1.0.0
+      es-errors: 1.3.0
+      gopd: 1.0.1
+    dev: false
+
   /define-properties@1.2.0:
     resolution:
       { integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA== }
@@ -4737,6 +4769,19 @@ packages:
       unbox-primitive: 1.0.2
       which-typed-array: 1.1.9
     dev: true
+
+  /es-define-property@1.0.0:
+    resolution:
+      { integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ== }
+    engines: { node: ">= 0.4" }
+    dependencies:
+      get-intrinsic: 1.2.4
+    dev: false
+
+  /es-errors@1.3.0:
+    resolution:
+      { integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw== }
+    engines: { node: ">= 0.4" }
 
   /es-set-tostringtag@2.0.1:
     resolution:
@@ -5512,6 +5557,10 @@ packages:
     resolution:
       { integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A== }
 
+  /function-bind@1.1.2:
+    resolution:
+      { integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA== }
+
   /function.prototype.name@1.1.5:
     resolution:
       { integrity: sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA== }
@@ -5546,6 +5595,17 @@ packages:
       has: 1.0.3
       has-symbols: 1.0.3
     dev: true
+
+  /get-intrinsic@1.2.4:
+    resolution:
+      { integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ== }
+    engines: { node: ">= 0.4" }
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      has-proto: 1.0.1
+      has-symbols: 1.0.3
+      hasown: 2.0.2
 
   /get-package-type@0.1.0:
     resolution:
@@ -5691,8 +5751,7 @@ packages:
     resolution:
       { integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA== }
     dependencies:
-      get-intrinsic: 1.2.0
-    dev: true
+      get-intrinsic: 1.2.4
 
   /graceful-fs@4.2.11:
     resolution:
@@ -5740,17 +5799,22 @@ packages:
       get-intrinsic: 1.2.0
     dev: true
 
+  /has-property-descriptors@1.0.2:
+    resolution:
+      { integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg== }
+    dependencies:
+      es-define-property: 1.0.0
+    dev: false
+
   /has-proto@1.0.1:
     resolution:
       { integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg== }
     engines: { node: ">= 0.4" }
-    dev: true
 
   /has-symbols@1.0.3:
     resolution:
       { integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A== }
     engines: { node: ">= 0.4" }
-    dev: true
 
   /has-tostringtag@1.0.0:
     resolution:
@@ -5766,6 +5830,13 @@ packages:
     engines: { node: ">= 0.4.0" }
     dependencies:
       function-bind: 1.1.1
+
+  /hasown@2.0.2:
+    resolution:
+      { integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ== }
+    engines: { node: ">= 0.4" }
+    dependencies:
+      function-bind: 1.1.2
 
   /header-case@2.0.4:
     resolution:
@@ -6260,6 +6331,11 @@ packages:
   /isarray@1.0.0:
     resolution:
       { integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ== }
+
+  /isarray@2.0.5:
+    resolution:
+      { integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw== }
+    dev: false
 
   /isbinaryfile@4.0.10:
     resolution:
@@ -6831,6 +6907,17 @@ packages:
       { integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw== }
     dev: true
 
+  /json-stable-stringify@1.1.1:
+    resolution:
+      { integrity: sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg== }
+    engines: { node: ">= 0.4" }
+    dependencies:
+      call-bind: 1.0.7
+      isarray: 2.0.5
+      jsonify: 0.0.1
+      object-keys: 1.1.1
+    dev: false
+
   /json5@1.0.2:
     resolution:
       { integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA== }
@@ -6844,6 +6931,11 @@ packages:
       { integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg== }
     engines: { node: ">=6" }
     hasBin: true
+
+  /jsonify@0.0.1:
+    resolution:
+      { integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg== }
+    dev: false
 
   /jsonparse@1.3.1:
     resolution:
@@ -7099,7 +7191,6 @@ packages:
   /lodash@4.17.10:
     resolution:
       { integrity: sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg== }
-    dev: false
 
   /lodash@4.17.21:
     resolution:
@@ -7614,7 +7705,6 @@ packages:
     resolution:
       { integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA== }
     engines: { node: ">= 0.4" }
-    dev: true
 
   /object.assign@4.1.4:
     resolution:
@@ -8527,6 +8617,19 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /set-function-length@1.2.2:
+    resolution:
+      { integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg== }
+    engines: { node: ">= 0.4" }
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.2.4
+      gopd: 1.0.1
+      has-property-descriptors: 1.0.2
+    dev: false
 
   /setimmediate@1.0.5:
     resolution:


### PR DESCRIPTION
This package is intended to be used for hashing a provided JS object in both Node.js and browser(eg-: for Next.js). Users will be provided an option to sort the JS object since order of properties is not guaranteed by JSON.stringify. This sorting will be done using this [package](https://github.com/ljharb/json-stable-stringify) which will be imported dynamically. In the case of a string being passed as a parameter to the algorithm, I've kept sorting optional.

On the browser side hashing will be done using the inbuild [SubteCrypto Web API](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto) which only provides the following algorithms for creating a hash.

- SHA-1
- SHA-256
- SHA-384
- SHA-512

In node.js we use the inbuilt [crypto module](https://nodejs.org/api/crypto.html), Even though node.js crpto module provides more algorithms than the ones available in the browser to maintain cross platform compatibility (browser and node.js), I've limited the available algorithms only the ones available in browser.

